### PR TITLE
Update tox versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ next
 
 * Remove more code that was for Django < 1.11.
 * Officially support Django 2.0 and Django 2.1.
+* Officially support django-otp 0.7.
 * Do not include test code in distribution, fix from @akx, PR #67.
 * Support for more complex user IDs (e.g. UUIDs), fix from @chromakey, see issue
   #64 / PR #66.

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ envlist =
     # Django 2.0 drops support for Python 2.7.
     py{35,36,37}-django20-dotp{03,04}
     # django-otp 0.5 adds support for Django 2.1
-    py{35,36,37}-django{21,22}-dotp{05,06,master}
+    py{35,36,37}-django{21,22}-dotp{05,06,07,master}
     # Django master requires Python 3.6.
-    py{36,37}-djangomaster-dotp{05,06,master}
+    py{36,37}-djangomaster-dotp{05,06,07,master}
     # Check code style.
     flake8
 skip_missing_interpreters = True
@@ -34,9 +34,9 @@ deps =
     dotp03: django-otp>=0.3,<0.4
     dotp04: django-otp>=0.4,<0.5
     dotp05: django-otp>=0.5,<0.6
-    # pip seems to be having issues installing from BitBucket at the moment.
     dotp06: django-otp>=0.6,<0.7
-    # dotpmaster: hg+https://bitbucket.org/psagers/django-otp#egg=subdir&subdirectory=django-otp
+    dotp07: django-otp>=0.7,<0.8
+    dotpmaster: https://codeload.github.com/django-otp/django-otp/zip/master
 
 [testenv:flake8]
 skip_install = True


### PR DESCRIPTION
Adds the just released django-otp 0.7 and adds back django-otp master.